### PR TITLE
command change handling and other event updates

### DIFF
--- a/example/index.css
+++ b/example/index.css
@@ -31,6 +31,10 @@ body {
   text-align: center;
 }
 
+#languages .p-CommandPalette-commandBottom {
+  font-style: italic;
+}
+
 .p-CommandPalette {
   background: #DDDDDD;
   border: 1px solid #CCCCCC;

--- a/example/index.ts
+++ b/example/index.ts
@@ -39,20 +39,20 @@ const p1Commands = [
 ];
 
 const p2Commands = [
-  createCommand('Romance languages', 'Italian', ''),
-  createCommand('Romance languages', 'Romanian', ''),
-  createCommand('Romance languages', 'French', ''),
-  createCommand('Romance languages', 'Spanish', ''),
-  createCommand('Romance languages', 'Portuguese', ''),
-  createCommand('Germanic languages', 'German', ''),
-  createCommand('Germanic languages', 'English', ''),
-  createCommand('Germanic languages', 'Danish', ''),
-  createCommand('Germanic languages', 'Swedish', ''),
-  createCommand('Germanic languages', 'Icelandic', ''),
-  createCommand('Germanic languages', 'Norwegian', ''),
-  createCommand('Germanic languages', 'Dutch', ''),
-  createCommand('Language isolates', 'Basque', ''),
-  createCommand('Language isolates', 'Korean', '')
+  createCommand('Romance languages', 'Italian', 'lingua italiana'),
+  createCommand('Romance languages', 'Romanian', 'limba română'),
+  createCommand('Romance languages', 'French', 'le français'),
+  createCommand('Romance languages', 'Spanish', 'español'),
+  createCommand('Romance languages', 'Portuguese', 'língua portuguesa'),
+  createCommand('Germanic languages', 'German', 'Deutsch'),
+  createCommand('Germanic languages', 'English', 'English'),
+  createCommand('Germanic languages', 'Danish', 'dansk sprog'),
+  createCommand('Germanic languages', 'Swedish', 'svenska'),
+  createCommand('Germanic languages', 'Icelandic', 'íslenska'),
+  createCommand('Germanic languages', 'Norwegian', 'norsk'),
+  createCommand('Germanic languages', 'Dutch', 'Nederlands'),
+  createCommand('Language isolates', 'Basque', 'Euskara'),
+  createCommand('Language isolates', 'Korean', '한국어/조선말')
 ];
 
 var timeout: number;
@@ -75,7 +75,9 @@ function createCommand(category: string, title: string, caption: string): Comman
 function main() {
   // Populate left palette commands.
   p1.add(p1Commands);
+  p1.id = 'civilizations';
   p2.add(p2Commands);
+  p2.id = 'languages';
   // Populate palettes panel.
   BoxPanel.setStretch(p1, 1);
   BoxPanel.setStretch(p2, 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -420,7 +420,7 @@ class CommandPalette extends Widget {
   /**
    * Search for a specific query string among command titles and captions.
    *
-   * @param query - The query string
+   * @param query - The query string.
    */
   search(query: string): void {
     let searchableItems = Object.keys(this._registry).reduce((acc, id) => {
@@ -568,7 +568,7 @@ class CommandPalette extends Widget {
   }
 
   /**
-   * Set the buffer to all registered items.
+   * Buffer a list of registration IDs, grouping them by category.
    *
    * @param ids - The list of registration ids to buffer.
    */
@@ -595,9 +595,9 @@ class CommandPalette extends Widget {
   }
 
   /**
-   * Set the buffer to search results.
+   * Buffer a list of search results without regrouping them.
    *
-   * @param items - The search results to be buffered.
+   * @param items - The search results to buffer.
    */
   private _bufferSearchResults(items: ICommandMatchResult[]): void {
     this._buffer = items.reduce((acc, val, idx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -425,7 +425,7 @@ class CommandPalette extends Widget {
   search(query: string): void {
     let searchableItems = Object.keys(this._registry).reduce((acc, id) => {
       let item = this._registry[id];
-      let title = item.text;
+      let title = [item.category, item.text].join(' ');
       let caption = item.caption;
       acc.push({ id, title, caption });
       return acc;

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,7 +363,6 @@ class CommandPalette extends Widget {
    * @param commands - An array of `CommandItem` instances.
    */
   add(commands: CommandItem[]): void {
-    let registrations: string[] = [];
     let constructor = this.constructor as typeof CommandPalette;
     commands.forEach(item => {
       let id = `palette-${++registrationSeed}`;
@@ -371,8 +370,6 @@ class CommandPalette extends Widget {
       constructor.idProperty.set(item, id);
       // Add the item to the private registry.
       this._registry[id] = item;
-      // Add the item to the list of registrations to dispose later.
-      registrations.push(id);
     });
     this._bufferAllItems();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -339,8 +339,6 @@ class CommandPalette extends Widget {
 
   /**
    * Construct a new command palette.
-   *
-   * @param commandRegistry - A command registry instance
    */
   constructor() {
     super();

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -56,13 +56,13 @@ interface ICommandSearchItem {
    */
   id: string;
   /**
-   * The command title.
+   * The primary search string.
    */
-  title: string;
+  primary: string;
   /**
-   * The command caption.
+   * The secondary search string.
    */
-  caption?: string;
+  secondary?: string;
 }
 
 /**
@@ -130,8 +130,8 @@ class FuzzyMatcher extends CommandMatcher {
    * should leak outside of this public API.
    */
   search(query: string, commands: ICommandSearchItem[]): ICommandMatchResult[] {
-    // Even though captions are optional, FuzzySearch needs them to be defined.
-    commands.forEach(item => item.caption = item.caption || '');
+    // Even though secondary strings are optional, they need to be defined.
+    commands.forEach(item => item.secondary = item.secondary || '');
     let primarySearch = new FuzzySearch(commands, {
       'minimumScore': 300,
       'termPath': this._primary


### PR DESCRIPTION
These commits entail the following:

* category is now included in the search, so even if a category string does not appear in the text or caption, it still appears in the results

* command change signals are reflected immediately in the palette: the palette remembers the state of what was selected and whether it was displaying a search result or not and groups the new items accordingly

* command addition causes search to be cleared so that all new commands will become visible

* command removal only affects the visual list of items if the item being removed was being displayed (*i.e.*, if a search result did not include the item being removed, nothing changes visually)