### PR TITLE
support for command enabled change signal

### DIFF
--- a/src/palette.ts
+++ b/src/palette.ts
@@ -561,8 +561,10 @@ class CommandPalette extends Widget {
     let { type, value } = this._buffer[parseInt(target.dataset['index'], 10)];
     switch (type) {
     case SearchResultType.Header:
-      let query = (value as IHeaderResult).queryPrefix;
-      console.log('category search', query);
+      let prefix = (value as IHeaderResult).queryPrefix;
+      let query = this.inputNode.value;
+      this.inputNode.value = prefix + query;
+      this.update();
       break;
     case SearchResultType.Command:
       let command = (value as ICommandResult).command;

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -598,8 +598,7 @@ class CommandPalette extends Widget {
     if (!indices.length) return;
     let selector = `.${HEADER_CLASS}, .${ITEM_CLASS}`;
     let nodes = this.contentNode.querySelectorAll(selector);
-    for (let i = 0; i < indices.length; ++i) {
-      let index = indices[i];
+    for (let index of indices) {
       let node = nodes[index];
       let args =(this._buffer[index].value as ICommandResult).args;
       if (command.isEnabled(args)) {


### PR DESCRIPTION
This PR covers the following:

* The palette now connects to the `ICommand` signal for changes in enabled status and re-draws the relevant nodes accordingly.

* The palette now enters the `queryPrefix` into the search box as a prefix to whatever was already there and `update`s itself.